### PR TITLE
Added a line

### DIFF
--- a/faq/faq-eol.md
+++ b/faq/faq-eol.md
@@ -11,4 +11,4 @@ We only release security fixes for the latest minor release (or major release, i
 
 **Disclaimer**: if this policy has to change due to a compatibility problem that prohibits the use of new detection technology, or impacts the stability of ClamAV infrastructure, we will announce the end of life for those versions four months before they become unsupported.
 
-Currently, every version from ClamAV .96 and down, including all minor versions, are unsupported.
+Currently, every version from ClamAV .97 and down, including all minor versions, are unsupported.

--- a/faq/faq-eol.md
+++ b/faq/faq-eol.md
@@ -10,3 +10,5 @@ We only check the CVD update for false positives using the latest minor release 
 We only release security fixes for the latest minor release (or major release, in case there has been no minor release after the last major release).
 
 **Disclaimer**: if this policy has to change due to a compatibility problem that prohibits the use of new detection technology, or impacts the stability of ClamAV infrastructure, we will announce the end of life for those versions four months before they become unsupported.
+
+Currently, every version from ClamAV .96 and down, including all minor versions, are unsupported.


### PR DESCRIPTION
Added a line to show which versions of ClamAV are no longer supported. Be sure to update on June 1st when .97 is EOL.