### PR TITLE
Remove LinuxPackages.net reference

### DIFF
--- a/faq/Installing.md
+++ b/faq/Installing.md
@@ -118,8 +118,6 @@ More info on [OpenCSW]
 
 ### Slackware <a id="slackware" class="anchor">&nbsp;</a> ###
 
-Linuxpackages.net provides third-party precompiled packages for Slackware. You can find them with this search query on that site.
-
 Martijn Dekker provides packages there that provide complete and semi-automatic integration with ClamAV's stock Sendmail package.
 
 ### OSX <a id="osx" class="anchor">&nbsp;</a> ###


### PR DESCRIPTION
LinuxPackages.net seems to be dead.
It appears to have died between Sep 2012 and Aug 2013 per Internet Archive.

http://web.archive.org/web/20130820231912/http://www.linuxpackages.net/